### PR TITLE
feat: Improve chunking strategy with langchain text splitters

### DIFF
--- a/rag_demo/chunking.py
+++ b/rag_demo/chunking.py
@@ -1,0 +1,149 @@
+"""
+Improved chunking strategies for RAG applications.
+
+This module provides multiple chunking strategies that respect sentence boundaries,
+support overlap, and use proven algorithms from langchain.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import List
+
+from langchain_text_splitters import (
+    RecursiveCharacterTextSplitter,
+    SentenceTransformersTokenTextSplitter,
+)
+
+
+class ChunkingStrategy(str, Enum):
+    """Available chunking strategies."""
+
+    RECURSIVE_CHARACTER = "recursive_character"
+    SENTENCE_TRANSFORMER = "sentence_transformer"
+    NAIVE = "naive"  # Original naive implementation for comparison
+
+
+class ChunkingConfig:
+    """
+    Configuration for chunking strategies.
+
+    Attributes:
+        chunk_size: Target size of chunks (in characters or tokens)
+        chunk_overlap: Overlap between chunks to preserve context
+        strategy: Chunking strategy to use
+    """
+
+    def __init__(
+        self,
+        chunk_size: int = 1024,
+        chunk_overlap: int = 200,
+        strategy: ChunkingStrategy = ChunkingStrategy.RECURSIVE_CHARACTER,
+    ):
+        """
+        Initialize chunking configuration.
+
+        Args:
+            chunk_size: Target size of chunks
+            chunk_overlap: Overlap between chunks
+            strategy: Chunking strategy to use
+        """
+        self.chunk_size = chunk_size
+        self.chunk_overlap = chunk_overlap
+        self.strategy = strategy
+
+
+def chunk_text_naive(text: str, chunk_size: int) -> List[str]:
+    """
+    Naive chunking by character length (original implementation).
+
+    This is kept for comparison but should not be used in production.
+
+    Args:
+        text: Text to chunk
+        chunk_size: Size of each chunk
+
+    Returns:
+        List of text chunks
+    """
+    return [text[i : i + chunk_size] for i in range(0, len(text), chunk_size)]
+
+
+def chunk_text_recursive_character(
+    text: str, chunk_size: int, chunk_overlap: int
+) -> List[str]:
+    """
+    Recursive character text splitter with overlap.
+
+    This strategy tries to split on paragraph boundaries first, then sentences,
+    then words, and finally characters if needed. It respects document structure
+    and includes overlap to preserve context.
+
+    Args:
+        text: Text to chunk
+        chunk_size: Target size of chunks (in characters)
+        chunk_overlap: Overlap between chunks (in characters)
+
+    Returns:
+        List of text chunks
+    """
+    splitter = RecursiveCharacterTextSplitter(
+        chunk_size=chunk_size,
+        chunk_overlap=chunk_overlap,
+        length_function=len,
+        separators=["\n\n", "\n", ". ", " ", ""],
+    )
+    return splitter.split_text(text)
+
+
+def chunk_text_sentence_transformer(
+    text: str, chunk_size: int, chunk_overlap: int
+) -> List[str]:
+    """
+    Sentence transformer token-based text splitter.
+
+    This strategy uses a sentence transformer model to split text based on
+    semantic boundaries. It's more sophisticated but requires more resources.
+
+    Args:
+        text: Text to chunk
+        chunk_size: Target size of chunks (in tokens)
+        chunk_overlap: Overlap between chunks (in tokens)
+
+    Returns:
+        List of text chunks
+    """
+    splitter = SentenceTransformersTokenTextSplitter(
+        chunk_size=chunk_size,
+        chunk_overlap=chunk_overlap,
+        model_name="BAAI/bge-small-en-v1.5",  # Same model used for embeddings
+    )
+    return splitter.split_text(text)
+
+
+def chunk_text(text: str, config: ChunkingConfig) -> List[str]:
+    """
+    Chunk text using the specified strategy.
+
+    Args:
+        text: Text to chunk
+        config: Chunking configuration
+
+    Returns:
+        List of text chunks
+
+    Raises:
+        ValueError: If an unknown strategy is specified
+    """
+    if config.strategy == ChunkingStrategy.NAIVE:
+        return chunk_text_naive(text, config.chunk_size)
+    elif config.strategy == ChunkingStrategy.RECURSIVE_CHARACTER:
+        return chunk_text_recursive_character(
+            text, config.chunk_size, config.chunk_overlap
+        )
+    elif config.strategy == ChunkingStrategy.SENTENCE_TRANSFORMER:
+        return chunk_text_sentence_transformer(
+            text, config.chunk_size, config.chunk_overlap
+        )
+    else:
+        raise ValueError(f"Unknown chunking strategy: {config.strategy}")


### PR DESCRIPTION
## Summary

Improves the chunking strategy by replacing the naive character-based splitting with production-ready chunking algorithms from langchain.

## Changes

- ✅ Added `langchain-text-splitters` dependency
- ✅ Implemented `RecursiveCharacterTextSplitter` with overlap support
- ✅ Added `SentenceTransformersTokenTextSplitter` for semantic-aware chunking
- ✅ Refactored chunking into separate module (`rag_demo/chunking.py`)
- ✅ Added command-line arguments for chunking strategy selection
- ✅ Support configurable chunk size and overlap
- ✅ Updated README with chunking strategy documentation
- ✅ Kept naive chunking for comparison purposes

## Improvements

### Before
- Naive character-based splitting (no respect for document structure)
- No overlap between chunks (context loss)
- Mid-sentence splits common
- Hard-coded chunk size

### After
- **Respects document structure**: Splits at paragraph/sentence boundaries when possible
- **Context preservation**: Overlap between chunks maintains continuity
- **Better boundaries**: Avoids mid-sentence splits
- **Multiple strategies**: Choose based on use case
- **Configurable**: Adjust chunk size and overlap via CLI

## Chunking Strategies

1. **recursive_character** (default): Uses langchain's RecursiveCharacterTextSplitter
   - Respects document structure (paragraphs → sentences → words → characters)
   - Includes overlap between chunks for better context preservation
   - Best for general-purpose RAG applications

2. **sentence_transformer**: Uses SentenceTransformersTokenTextSplitter
   - Semantic-aware chunking based on token boundaries
   - Uses the same model as embeddings (BAAI/bge-small-en-v1.5)
   - Best for semantic similarity tasks

3. **naive**: Original simple character-based splitting
   - Kept for comparison purposes
   - Not recommended for production

## Usage Examples

```bash
# Use default recursive character splitter
poetry run python -m rag_demo

# Custom chunk size and overlap
poetry run python -m rag_demo --chunking-strategy recursive_character --chunk-size 1024 --chunk-overlap 200

# Use sentence transformer strategy
poetry run python -m rag_demo --chunking-strategy sentence_transformer

# Compare with original naive approach
poetry run python -m rag_demo --chunking-strategy naive --chunk-size 2048
```

## Testing

- ✅ Code compiles without errors
- ✅ All imports resolve correctly
- ✅ Backward compatible (naive strategy still available)
- ✅ Default behavior uses improved chunking

## Related

Addresses BACKLOG item: "Try a different chunking algorithm from langchain or Llama Index."

## Migration Notes

- Default chunk size changed from 2048 to 1024 (better granularity with overlap)
- Default chunking strategy is now `recursive_character` instead of naive
- To use old behavior: `--chunking-strategy naive --chunk-size 2048`