### PR TITLE
feat: Add two-stage retrieval with reranking

### DIFF
--- a/rag_demo/chunking.py
+++ b/rag_demo/chunking.py
@@ -1,0 +1,149 @@
+"""
+Improved chunking strategies for RAG applications.
+
+This module provides multiple chunking strategies that respect sentence boundaries,
+support overlap, and use proven algorithms from langchain.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import List
+
+from langchain_text_splitters import (
+    RecursiveCharacterTextSplitter,
+    SentenceTransformersTokenTextSplitter,
+)
+
+
+class ChunkingStrategy(str, Enum):
+    """Available chunking strategies."""
+
+    RECURSIVE_CHARACTER = "recursive_character"
+    SENTENCE_TRANSFORMER = "sentence_transformer"
+    NAIVE = "naive"  # Original naive implementation for comparison
+
+
+class ChunkingConfig:
+    """
+    Configuration for chunking strategies.
+
+    Attributes:
+        chunk_size: Target size of chunks (in characters or tokens)
+        chunk_overlap: Overlap between chunks to preserve context
+        strategy: Chunking strategy to use
+    """
+
+    def __init__(
+        self,
+        chunk_size: int = 1024,
+        chunk_overlap: int = 200,
+        strategy: ChunkingStrategy = ChunkingStrategy.RECURSIVE_CHARACTER,
+    ):
+        """
+        Initialize chunking configuration.
+
+        Args:
+            chunk_size: Target size of chunks
+            chunk_overlap: Overlap between chunks
+            strategy: Chunking strategy to use
+        """
+        self.chunk_size = chunk_size
+        self.chunk_overlap = chunk_overlap
+        self.strategy = strategy
+
+
+def chunk_text_naive(text: str, chunk_size: int) -> List[str]:
+    """
+    Naive chunking by character length (original implementation).
+
+    This is kept for comparison but should not be used in production.
+
+    Args:
+        text: Text to chunk
+        chunk_size: Size of each chunk
+
+    Returns:
+        List of text chunks
+    """
+    return [text[i : i + chunk_size] for i in range(0, len(text), chunk_size)]
+
+
+def chunk_text_recursive_character(
+    text: str, chunk_size: int, chunk_overlap: int
+) -> List[str]:
+    """
+    Recursive character text splitter with overlap.
+
+    This strategy tries to split on paragraph boundaries first, then sentences,
+    then words, and finally characters if needed. It respects document structure
+    and includes overlap to preserve context.
+
+    Args:
+        text: Text to chunk
+        chunk_size: Target size of chunks (in characters)
+        chunk_overlap: Overlap between chunks (in characters)
+
+    Returns:
+        List of text chunks
+    """
+    splitter = RecursiveCharacterTextSplitter(
+        chunk_size=chunk_size,
+        chunk_overlap=chunk_overlap,
+        length_function=len,
+        separators=["\n\n", "\n", ". ", " ", ""],
+    )
+    return splitter.split_text(text)
+
+
+def chunk_text_sentence_transformer(
+    text: str, chunk_size: int, chunk_overlap: int
+) -> List[str]:
+    """
+    Sentence transformer token-based text splitter.
+
+    This strategy uses a sentence transformer model to split text based on
+    semantic boundaries. It's more sophisticated but requires more resources.
+
+    Args:
+        text: Text to chunk
+        chunk_size: Target size of chunks (in tokens)
+        chunk_overlap: Overlap between chunks (in tokens)
+
+    Returns:
+        List of text chunks
+    """
+    splitter = SentenceTransformersTokenTextSplitter(
+        chunk_size=chunk_size,
+        chunk_overlap=chunk_overlap,
+        model_name="BAAI/bge-small-en-v1.5",  # Same model used for embeddings
+    )
+    return splitter.split_text(text)
+
+
+def chunk_text(text: str, config: ChunkingConfig) -> List[str]:
+    """
+    Chunk text using the specified strategy.
+
+    Args:
+        text: Text to chunk
+        config: Chunking configuration
+
+    Returns:
+        List of text chunks
+
+    Raises:
+        ValueError: If an unknown strategy is specified
+    """
+    if config.strategy == ChunkingStrategy.NAIVE:
+        return chunk_text_naive(text, config.chunk_size)
+    elif config.strategy == ChunkingStrategy.RECURSIVE_CHARACTER:
+        return chunk_text_recursive_character(
+            text, config.chunk_size, config.chunk_overlap
+        )
+    elif config.strategy == ChunkingStrategy.SENTENCE_TRANSFORMER:
+        return chunk_text_sentence_transformer(
+            text, config.chunk_size, config.chunk_overlap
+        )
+    else:
+        raise ValueError(f"Unknown chunking strategy: {config.strategy}")

--- a/rag_demo/reranker.py
+++ b/rag_demo/reranker.py
@@ -1,0 +1,126 @@
+"""
+Reranking module for two-stage retrieval in RAG applications.
+
+Implements reranking using cross-encoder models to improve retrieval quality
+by reranking initial vector search results.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+import requests
+
+
+class Reranker:
+    """
+    Reranker for two-stage retrieval.
+
+    Uses cross-encoder models to rerank documents based on query relevance.
+    This improves retrieval quality by processing query-document pairs together.
+    """
+
+    def __init__(
+        self,
+        model_name: str = "BAAI/bge-reranker-base",
+        api_url: Optional[str] = None,
+        api_key: Optional[str] = None,
+    ):
+        """
+        Initialize reranker.
+
+        Args:
+            model_name: Hugging Face model name for reranking
+            api_url: Optional custom API URL (defaults to Hugging Face Inference API)
+            api_key: Optional API key (uses HF_API_KEY env var if not provided)
+        """
+        self.model_name = model_name
+        self.api_url = api_url or f"https://api-inference.huggingface.co/models/{model_name}"
+        self.api_key = api_key
+
+    def rerank(
+        self,
+        query: str,
+        documents: List[str],
+        top_n: Optional[int] = None,
+    ) -> List[tuple[str, float]]:
+        """
+        Rerank documents based on query relevance.
+
+        Args:
+            query: User query
+            documents: List of document texts to rerank
+            top_n: Number of top documents to return (None returns all)
+
+        Returns:
+            List of tuples (document_text, relevance_score) sorted by relevance
+        """
+        if not documents:
+            return []
+
+        # Prepare input pairs for reranking
+        # Format: [query, document] pairs
+        inputs = [[query, doc] for doc in documents]
+
+        headers = {
+            "Authorization": f"Bearer {self.api_key or ''}",
+            "Content-Type": "application/json",
+            "x-wait-for-model": "true",
+        }
+
+        try:
+            response = requests.post(
+                self.api_url,
+                headers=headers,
+                json={"inputs": inputs},
+                timeout=30,
+            )
+            response.raise_for_status()
+            scores = response.json()
+
+            # Handle different response formats
+            if isinstance(scores, list) and len(scores) > 0:
+                if isinstance(scores[0], list):
+                    # Format: [[score1], [score2], ...]
+                    scores = [s[0] if isinstance(s, list) else s for s in scores]
+                elif isinstance(scores[0], dict):
+                    # Format: [{"score": ...}, ...]
+                    scores = [s.get("score", 0.0) for s in scores]
+
+            # Pair documents with scores and sort by score (descending)
+            doc_scores = list(zip(documents, scores))
+            doc_scores.sort(key=lambda x: x[1], reverse=True)
+
+            # Return top_n if specified
+            if top_n is not None:
+                return doc_scores[:top_n]
+
+            return doc_scores
+
+        except requests.exceptions.RequestException as e:
+            print(f"Warning: Reranking failed: {e}")
+            print("Falling back to original order without reranking.")
+            # Return documents in original order with neutral scores
+            return [(doc, 0.5) for doc in documents]
+
+    def rerank_with_metadata(
+        self,
+        query: str,
+        documents: List[tuple[str, float]],
+        top_n: Optional[int] = None,
+    ) -> List[tuple[str, float]]:
+        """
+        Rerank documents that already have scores (e.g., from vector search).
+
+        Args:
+            query: User query
+            documents: List of tuples (document_text, initial_score)
+            top_n: Number of top documents to return (None returns all)
+
+        Returns:
+            List of tuples (document_text, reranked_score) sorted by relevance
+        """
+        # Extract just the document texts for reranking
+        doc_texts = [doc[0] for doc in documents]
+        return self.rerank(query, doc_texts, top_n=top_n)
+


### PR DESCRIPTION
## Summary

Adds two-stage retrieval with reranking to improve RAG retrieval quality. This follows the approach described in [Pinecone's Rerankers Guide](https://www.pinecone.io/learn/series/rag/rerankers/).

## Changes

- ✅ Added `reranker.py` module using Hugging Face cross-encoder models
- ✅ Implemented two-stage retrieval: vector search + reranking
- ✅ Added command-line arguments for reranking configuration
- ✅ Updated query flow to support optional reranking
- ✅ Updated README with reranking documentation

## How Two-Stage Retrieval Works

1. **Stage 1 (Vector Search)**: Retrieve a larger set of documents (e.g., top 25) using fast vector similarity search
2. **Stage 2 (Reranking)**: Use a cross-encoder reranker model to rerank the retrieved documents and select the most relevant ones (e.g., top 5)

## Why Reranking?

- **Better accuracy**: Rerankers process query-document pairs together, avoiding information loss from vector compression
- **Maximizes recall**: Retrieve more documents initially, then rerank to get the best ones
- **Improves LLM performance**: Better context leads to better answers

## Usage

```bash
# Enable reranking (recommended for better results)
poetry run python -m rag_demo --use-reranker

# Customize retrieval and reranking parameters
poetry run python -m rag_demo --use-reranker --retrieval-top-k 30 --rerank-top-n 5

# Use a different reranker model
poetry run python -m rag_demo --use-reranker --reranker-model "BAAI/bge-reranker-large"

# Without reranking (single-stage retrieval, faster but less accurate)
poetry run python -m rag_demo
```

## Command-Line Options

- `--use-reranker`: Enable two-stage retrieval with reranking
- `--retrieval-top-k`: Number of documents to retrieve in first stage (default: 25)
- `--rerank-top-n`: Number of top documents after reranking (default: 5)
- `--reranker-model`: Reranker model to use (default: BAAI/bge-reranker-base)

## Example Output

```
Stage 1 (Vector Search): Retrieved 25 documents
Vector search scores: ['45.23', '44.12', '43.89', ...]

Stage 2 (Reranking): Reranking 25 documents...
Reranked to top 5 documents
Reranked scores: ['0.9234', '0.8912', '0.8765', '0.8456', '0.8123']
```

## Technical Details

- Uses Hugging Face Inference API for reranking
- Default model: BAAI/bge-reranker-base (can be changed)
- Reranking is optional and opt-in (backward compatible)
- Handles API failures gracefully with fallback to original order

## References

- [Pinecone Rerankers Guide](https://www.pinecone.io/learn/series/rag/rerankers/)
- [BGE Reranker Models](https://huggingface.co/BAAI/bge-reranker-base)