### PR TITLE
feat: add malicious query router guardrail

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,20 @@ Reranked to top 5 documents
 Reranked scores: ['0.9234', '0.8912', '0.8765', '0.8456', '0.8123']
 ```
 
+#### Query Router Guardrail
+
+Following the guidance in the [LangChain overview](https://docs.langchain.com/oss/python/langchain/overview), the demo now includes a lightweight **query router** to catch obvious malicious intent (prompt-injection phrases, destructive shell commands, credential harvesting attempts) before any retrieval or model call happens.
+
+- Enabled by default; disable with `--disable-query-router`
+- Checks for suspicious keywords and rejects empty/oversized queries
+- Blocks the request and prompts the user to rephrase if the query is unsafe
+
+Example guardrail output:
+```
+Query router decision: Query rejected: detected potentially malicious intent (contains disallowed instructions).
+This query was blocked because it may contain malicious intent. Please rephrase your request with benign language.
+```
+
 ### Check chunks table first 5 rows
 ```
 psql -h localhost -p 6432 -U postgres rag_demo -c "SELECT * FROM chunks LIMIT 5;"

--- a/rag_demo/chunking.py
+++ b/rag_demo/chunking.py
@@ -1,0 +1,149 @@
+"""
+Improved chunking strategies for RAG applications.
+
+This module provides multiple chunking strategies that respect sentence boundaries,
+support overlap, and use proven algorithms from langchain.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import List
+
+from langchain_text_splitters import (
+    RecursiveCharacterTextSplitter,
+    SentenceTransformersTokenTextSplitter,
+)
+
+
+class ChunkingStrategy(str, Enum):
+    """Available chunking strategies."""
+
+    RECURSIVE_CHARACTER = "recursive_character"
+    SENTENCE_TRANSFORMER = "sentence_transformer"
+    NAIVE = "naive"  # Original naive implementation for comparison
+
+
+class ChunkingConfig:
+    """
+    Configuration for chunking strategies.
+
+    Attributes:
+        chunk_size: Target size of chunks (in characters or tokens)
+        chunk_overlap: Overlap between chunks to preserve context
+        strategy: Chunking strategy to use
+    """
+
+    def __init__(
+        self,
+        chunk_size: int = 1024,
+        chunk_overlap: int = 200,
+        strategy: ChunkingStrategy = ChunkingStrategy.RECURSIVE_CHARACTER,
+    ):
+        """
+        Initialize chunking configuration.
+
+        Args:
+            chunk_size: Target size of chunks
+            chunk_overlap: Overlap between chunks
+            strategy: Chunking strategy to use
+        """
+        self.chunk_size = chunk_size
+        self.chunk_overlap = chunk_overlap
+        self.strategy = strategy
+
+
+def chunk_text_naive(text: str, chunk_size: int) -> List[str]:
+    """
+    Naive chunking by character length (original implementation).
+
+    This is kept for comparison but should not be used in production.
+
+    Args:
+        text: Text to chunk
+        chunk_size: Size of each chunk
+
+    Returns:
+        List of text chunks
+    """
+    return [text[i : i + chunk_size] for i in range(0, len(text), chunk_size)]
+
+
+def chunk_text_recursive_character(
+    text: str, chunk_size: int, chunk_overlap: int
+) -> List[str]:
+    """
+    Recursive character text splitter with overlap.
+
+    This strategy tries to split on paragraph boundaries first, then sentences,
+    then words, and finally characters if needed. It respects document structure
+    and includes overlap to preserve context.
+
+    Args:
+        text: Text to chunk
+        chunk_size: Target size of chunks (in characters)
+        chunk_overlap: Overlap between chunks (in characters)
+
+    Returns:
+        List of text chunks
+    """
+    splitter = RecursiveCharacterTextSplitter(
+        chunk_size=chunk_size,
+        chunk_overlap=chunk_overlap,
+        length_function=len,
+        separators=["\n\n", "\n", ". ", " ", ""],
+    )
+    return splitter.split_text(text)
+
+
+def chunk_text_sentence_transformer(
+    text: str, chunk_size: int, chunk_overlap: int
+) -> List[str]:
+    """
+    Sentence transformer token-based text splitter.
+
+    This strategy uses a sentence transformer model to split text based on
+    semantic boundaries. It's more sophisticated but requires more resources.
+
+    Args:
+        text: Text to chunk
+        chunk_size: Target size of chunks (in tokens)
+        chunk_overlap: Overlap between chunks (in tokens)
+
+    Returns:
+        List of text chunks
+    """
+    splitter = SentenceTransformersTokenTextSplitter(
+        chunk_size=chunk_size,
+        chunk_overlap=chunk_overlap,
+        model_name="BAAI/bge-small-en-v1.5",  # Same model used for embeddings
+    )
+    return splitter.split_text(text)
+
+
+def chunk_text(text: str, config: ChunkingConfig) -> List[str]:
+    """
+    Chunk text using the specified strategy.
+
+    Args:
+        text: Text to chunk
+        config: Chunking configuration
+
+    Returns:
+        List of text chunks
+
+    Raises:
+        ValueError: If an unknown strategy is specified
+    """
+    if config.strategy == ChunkingStrategy.NAIVE:
+        return chunk_text_naive(text, config.chunk_size)
+    elif config.strategy == ChunkingStrategy.RECURSIVE_CHARACTER:
+        return chunk_text_recursive_character(
+            text, config.chunk_size, config.chunk_overlap
+        )
+    elif config.strategy == ChunkingStrategy.SENTENCE_TRANSFORMER:
+        return chunk_text_sentence_transformer(
+            text, config.chunk_size, config.chunk_overlap
+        )
+    else:
+        raise ValueError(f"Unknown chunking strategy: {config.strategy}")

--- a/rag_demo/reranker.py
+++ b/rag_demo/reranker.py
@@ -1,0 +1,126 @@
+"""
+Reranking module for two-stage retrieval in RAG applications.
+
+Implements reranking using cross-encoder models to improve retrieval quality
+by reranking initial vector search results.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+import requests
+
+
+class Reranker:
+    """
+    Reranker for two-stage retrieval.
+
+    Uses cross-encoder models to rerank documents based on query relevance.
+    This improves retrieval quality by processing query-document pairs together.
+    """
+
+    def __init__(
+        self,
+        model_name: str = "BAAI/bge-reranker-base",
+        api_url: Optional[str] = None,
+        api_key: Optional[str] = None,
+    ):
+        """
+        Initialize reranker.
+
+        Args:
+            model_name: Hugging Face model name for reranking
+            api_url: Optional custom API URL (defaults to Hugging Face Inference API)
+            api_key: Optional API key (uses HF_API_KEY env var if not provided)
+        """
+        self.model_name = model_name
+        self.api_url = api_url or f"https://api-inference.huggingface.co/models/{model_name}"
+        self.api_key = api_key
+
+    def rerank(
+        self,
+        query: str,
+        documents: List[str],
+        top_n: Optional[int] = None,
+    ) -> List[tuple[str, float]]:
+        """
+        Rerank documents based on query relevance.
+
+        Args:
+            query: User query
+            documents: List of document texts to rerank
+            top_n: Number of top documents to return (None returns all)
+
+        Returns:
+            List of tuples (document_text, relevance_score) sorted by relevance
+        """
+        if not documents:
+            return []
+
+        # Prepare input pairs for reranking
+        # Format: [query, document] pairs
+        inputs = [[query, doc] for doc in documents]
+
+        headers = {
+            "Authorization": f"Bearer {self.api_key or ''}",
+            "Content-Type": "application/json",
+            "x-wait-for-model": "true",
+        }
+
+        try:
+            response = requests.post(
+                self.api_url,
+                headers=headers,
+                json={"inputs": inputs},
+                timeout=30,
+            )
+            response.raise_for_status()
+            scores = response.json()
+
+            # Handle different response formats
+            if isinstance(scores, list) and len(scores) > 0:
+                if isinstance(scores[0], list):
+                    # Format: [[score1], [score2], ...]
+                    scores = [s[0] if isinstance(s, list) else s for s in scores]
+                elif isinstance(scores[0], dict):
+                    # Format: [{"score": ...}, ...]
+                    scores = [s.get("score", 0.0) for s in scores]
+
+            # Pair documents with scores and sort by score (descending)
+            doc_scores = list(zip(documents, scores))
+            doc_scores.sort(key=lambda x: x[1], reverse=True)
+
+            # Return top_n if specified
+            if top_n is not None:
+                return doc_scores[:top_n]
+
+            return doc_scores
+
+        except requests.exceptions.RequestException as e:
+            print(f"Warning: Reranking failed: {e}")
+            print("Falling back to original order without reranking.")
+            # Return documents in original order with neutral scores
+            return [(doc, 0.5) for doc in documents]
+
+    def rerank_with_metadata(
+        self,
+        query: str,
+        documents: List[tuple[str, float]],
+        top_n: Optional[int] = None,
+    ) -> List[tuple[str, float]]:
+        """
+        Rerank documents that already have scores (e.g., from vector search).
+
+        Args:
+            query: User query
+            documents: List of tuples (document_text, initial_score)
+            top_n: Number of top documents to return (None returns all)
+
+        Returns:
+            List of tuples (document_text, reranked_score) sorted by relevance
+        """
+        # Extract just the document texts for reranking
+        doc_texts = [doc[0] for doc in documents]
+        return self.rerank(query, doc_texts, top_n=top_n)
+

--- a/rag_demo/router.py
+++ b/rag_demo/router.py
@@ -1,0 +1,97 @@
+"""Query routing utilities for detecting malicious queries.
+
+The router implements lightweight heuristics to catch obvious malicious intent
+before the request reaches the retrieval pipeline. The implementation is
+inspired by the safety guardrails recommended in the LangChain overview docs,
+which suggest inserting routing/guard components ahead of model calls to protect
+systems from prompt-injection and jailbreak attempts.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import re
+from typing import Iterable, List, Pattern, Tuple
+
+
+DEFAULT_PATTERNS: Tuple[str, ...] = (
+    r"(?i)ignore\s+previous\s+instructions",
+    r"(?i)drop\s+table",
+    r"(?i)truncate\s+table",
+    r"(?i)rm\s+-rf",
+    r"(?i)format\s+c:\\",
+    r"(?i)delete\s+from",
+    r"(?i)passwords?",
+    r"(?i)api\s+keys?",
+    r"(?i)system\s+prompt",
+    r"(?i)powershell",
+    r"(?i)malware",
+    r"(?i)backdoor",
+    r"(?i)virus",
+)
+
+
+@dataclass(slots=True)
+class QueryRouter:
+    """Rule-based router that flags potentially malicious queries.
+
+    Attributes:
+        blocked_patterns: Regex patterns that indicate malicious intent.
+        max_length: Optional maximum query length. Overly long queries are often
+            associated with prompt-injection attempts that try to stuff large
+            instructions into the context window.
+    """
+
+    blocked_patterns: Iterable[str] = field(default_factory=lambda: DEFAULT_PATTERNS)
+    max_length: int = 2048
+
+    def __post_init__(self) -> None:
+        self._compiled: List[Pattern[str]] = [re.compile(pat) for pat in self.blocked_patterns]
+
+    def inspect(self, query: str) -> tuple[bool, str]:
+        """Inspect a query and return a tuple of (is_allowed, reason).
+
+        Args:
+            query: Raw user query text.
+
+        Returns:
+            Tuple containing a boolean indicating if the query is allowed and a
+            message describing the decision.
+        """
+
+        cleaned_query = query.strip()
+        if not cleaned_query:
+            return False, "Query is empty."
+
+        if len(cleaned_query) > self.max_length:
+            return (
+                False,
+                "Query rejected: exceeds maximum allowed length."
+                " Please shorten your question and try again.",
+            )
+
+        for pattern in self._compiled:
+            if pattern.search(cleaned_query):
+                return (
+                    False,
+                    "Query rejected: detected potentially malicious intent"
+                    " (contains disallowed instructions).",
+                )
+
+        return True, "Query accepted."
+
+
+def is_query_safe(query: str, router: QueryRouter | None = None) -> tuple[bool, str]:
+    """Helper that checks if a query is safe using the provided router.
+
+    Args:
+        query: User provided query.
+        router: Optional pre-configured router. When omitted a default router is
+            created.
+
+    Returns:
+        Tuple of (is_allowed, message)
+    """
+
+    router = router or QueryRouter()
+    return router.inspect(query)


### PR DESCRIPTION
## Summary

- add a rule-based query router that blocks obvious malicious or prompt-injection attempts before retrieval
- integrate the router into the CLI with an option to disable it when needed
- document the guardrail in the README, citing the LangChain overview guidance on routing/guardrails (https://docs.langchain.com/oss/python/langchain/overview)

## Testing

- python3 -m py_compile rag_demo/router.py rag_demo/__main__.py